### PR TITLE
Pass ... to a() in valueBox and infoBox

### DIFF
--- a/R/boxes.R
+++ b/R/boxes.R
@@ -11,13 +11,14 @@
 #' @param color A color for the box. Valid colors are listed in
 #'   \link{validColors}.
 #' @param href An optional URL to link to.
+#' @param ... Passed to a() if href used
 #'
 #' @family boxes
 #' @seealso \code{\link{box}} for usage examples.
 #'
 #' @export
 valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
-  href = NULL)
+  href = NULL, ...)
 {
   validateColor(color)
   if (!is.null(icon)) tagAssert(icon, type = "i")
@@ -31,7 +32,7 @@ valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
   )
 
   if (!is.null(href))
-    boxContent <- a(href = href, boxContent)
+    boxContent <- a(href = href, boxContent, ...)
 
   div(class = if (!is.null(width)) paste0("col-sm-", width),
     boxContent
@@ -58,6 +59,7 @@ valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
 #'   content; the icon will use the same color with a slightly darkened
 #'   background.
 #' @param href An optional URL to link to.
+#' @param ... Passed to a() if href used
 #'
 #' @family boxes
 #' @seealso \code{\link{box}} for usage examples.
@@ -65,7 +67,7 @@ valueBox <- function(value, subtitle, icon = NULL, color = "aqua", width = 4,
 #' @export
 infoBox <- function(title, value = NULL, subtitle = NULL,
   icon = shiny::icon("bar-chart"), color = "aqua", width = 4, href = NULL,
-  fill = FALSE) {
+  fill = FALSE, ...) {
 
   validateColor(color)
   tagAssert(icon, type = "i")
@@ -88,7 +90,7 @@ infoBox <- function(title, value = NULL, subtitle = NULL,
   )
 
   if (!is.null(href))
-    boxContent <- a(href = href, boxContent)
+    boxContent <- a(href = href, boxContent, ...)
 
   div(class = if (!is.null(width)) paste0("col-sm-", width),
     boxContent

--- a/man/infoBox.Rd
+++ b/man/infoBox.Rd
@@ -6,7 +6,7 @@
 \usage{
 infoBox(title, value = NULL, subtitle = NULL,
   icon = shiny::icon("bar-chart"), color = "aqua", width = 4,
-  href = NULL, fill = FALSE)
+  href = NULL, fill = FALSE, ...)
 }
 \arguments{
 \item{title}{Title text.}
@@ -33,6 +33,8 @@ content, and the \code{color} argument for the background of the icon. If
 \code{TRUE}, use the \code{color} argument for the background of the
 content; the icon will use the same color with a slightly darkened
 background.}
+
+\item{...}{Passed to a() if href used}
 }
 \description{
 An info box displays a large icon on the left side, and a title, value

--- a/man/valueBox.Rd
+++ b/man/valueBox.Rd
@@ -5,7 +5,7 @@
 \title{Create a value box for the main body of a dashboard.}
 \usage{
 valueBox(value, subtitle, icon = NULL, color = "aqua", width = 4,
-  href = NULL)
+  href = NULL, ...)
 }
 \arguments{
 \item{value}{The value to display in the box. Usually a number or short text.}
@@ -24,6 +24,8 @@ layouts, use \code{NULL} for the width; the width is set by the column that
 contains the box.}
 
 \item{href}{An optional URL to link to.}
+
+\item{...}{Passed to a() if href used}
 }
 \description{
 A value box displays a value (usually a number) in large text, with a smaller


### PR DESCRIPTION
I needed this for an application I had, but fair play if you don't think it suitable for master branch.  Thought I'd put it out there at the very least.  Minor change to allow more customisation of the href link for value and Info boxes.

I needed this as otherwise the Shiny app stops/greys out when you click on the link, so I needed to add a `target="_blank"` to the infoBox. e.g.

```
url <- reactive_url()

infoBox("Download", 
              href = x, 
              target = "_blank",
              value = "Data,
              subtitle = "Click to download. Up to 1GB per file", 
              icon = icon("download"))
```