### PR TITLE
Add ability to restore bookmarked tabs

### DIFF
--- a/R/dashboardSidebar.R
+++ b/R/dashboardSidebar.R
@@ -242,9 +242,77 @@ sidebarSearchForm <- function(textId, buttonId, label = "Search...",
 sidebarMenu <- function(..., id = NULL, .list = NULL) {
   items <- c(list(...), .list)
 
-  tags$ul(id = id, class = "sidebar-menu",
-    items
-  )
+  # Restore a selected tab from bookmarked state. Bookmarking was added in Shiny
+  # 0.14.
+  if (packageVersion("shiny") >= "0.14") {
+    selectedTabName <- restoreInput(id = id, default = NULL)
+    if (!is.null(selectedTabName)) {
+      # Find the menuItem or menuSubItem with a `tabname` that matches
+      # `selectedTab`. Then set `data-start-selected` to 1 for that tab and 0
+      # for all others.
+
+      # Given a menuItem and a logical value for `selected`, set the
+      # data-start-selected attribute to the appropriate value (1 or 0).
+      selectItem <- function(item, selected) {
+        if (length(item$children) == 0) {
+          return(item)
+        }
+
+        if (selected) value <- 1
+        else          value <- NULL
+
+        # Try to find the child <a data-toggle="tab"> tag and then set
+        # data-start-selected="1". The []<- assignment is to preserve
+        # attributes.
+        item$children[] <- lapply(item$children, function(child) {
+          # Find the appro
+          if (inherits(child, "shiny.tag") &&
+              child$name == "a" &&
+              equals(child$attribs[["data-toggle"]], "tab"))
+          {
+            child$attribs[["data-start-selected"]] <- value
+          }
+
+          child
+        })
+
+        item
+      }
+
+      # Given a menuItem and a tabName (string), return TRUE if the menuItem has
+      # that tabName, FALSE otherwise.
+      itemHasTabName <- function(item, tabName) {
+        # Must be a <li> tag
+        if (!(inherits(item, "shiny.tag") && item$name == "li")) {
+          return(FALSE)
+        }
+
+        # Look for an <a> child with data-value=tabName
+        found <- FALSE
+        lapply(item$children, function(child) {
+          if (inherits(child, "shiny.tag") &&
+              child$name == "a" &&
+              equals(child$attribs[["data-value"]], tabName))
+          {
+            found <<- TRUE
+          }
+        })
+
+        found
+      }
+
+      # Actually do the work of marking selected tabs and unselected ones.
+      items <- lapply(items, function(item) {
+        selected <- itemHasTabName(item, selectedTabName)
+        selectItem(item, selected)
+      })
+    }
+  }
+
+  # Use do.call so that we don't add an extra list layer to the children of the
+  # ul tag. This makes it a little easier to traverse the tree to search for
+  # selected items to restore.
+  do.call(tags$ul, c(id = id, class = "sidebar-menu", items))
 }
 
 #' @rdname sidebarMenu

--- a/R/dashboardSidebar.R
+++ b/R/dashboardSidebar.R
@@ -265,11 +265,8 @@ sidebarMenu <- function(..., id = NULL, .list = NULL) {
         # data-start-selected="1". The []<- assignment is to preserve
         # attributes.
         item$children[] <- lapply(item$children, function(child) {
-          # Find the appro
-          if (inherits(child, "shiny.tag") &&
-              child$name == "a" &&
-              equals(child$attribs[["data-toggle"]], "tab"))
-          {
+          # Find the appropriate <a> child
+          if (tagMatches(child, name = "a", `data-toggle` = "tab")) {
             child$attribs[["data-start-selected"]] <- value
           }
 
@@ -283,17 +280,14 @@ sidebarMenu <- function(..., id = NULL, .list = NULL) {
       # that tabName, FALSE otherwise.
       itemHasTabName <- function(item, tabName) {
         # Must be a <li> tag
-        if (!(inherits(item, "shiny.tag") && item$name == "li")) {
+        if (!tagMatches(item, name = "li")) {
           return(FALSE)
         }
 
         # Look for an <a> child with data-value=tabName
         found <- FALSE
         lapply(item$children, function(child) {
-          if (inherits(child, "shiny.tag") &&
-              child$name == "a" &&
-              equals(child$attribs[["data-value"]], tabName))
-          {
+          if (tagMatches(child, name = "a", `data-value` = tabName)) {
             found <<- TRUE
           }
         })

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,3 +162,39 @@ equals <- function(a, b) {
 
   a == b
 }
+
+
+# Return TRUE if a tag object matches a specific id, and/or tag name, and/or
+# class, and or other arbitrary tag attributes. Put the args after ... so that
+# caller must use named arguments.
+tagMatches <- function(item, ..., id = NULL, name = NULL, class = NULL) {
+  dots <- list(...)
+  if (!inherits(item, "shiny.tag")) {
+    return(FALSE)
+  }
+  if (!is.null(id) && !equals(item$attribs$id, id)) {
+    return(FALSE)
+  }
+  if (!is.null(name) && !equals(item$name, name)) {
+    return(FALSE)
+  }
+  if (!is.null(class)) {
+    if (is.null(item$attribs$class)) {
+      return(FALSE)
+    }
+    classes <- strsplit(item$attribs$class, " ")[[1]]
+    if (! class %in% classes) {
+      return(FALSE)
+    }
+  }
+
+  for (i in seq_along(dots)) {
+    arg     <- dots[[i]]
+    argName <- names(dots)[[i]]
+    if (!equals(item$attribs[[argName]], arg)) {
+      return(FALSE)
+    }
+  }
+
+  TRUE
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -139,3 +139,26 @@ validateTabName <- function(name) {
     stop("tabName must not have a '.' in it.")
   }
 }
+
+
+# This is like a==b, except that if a or b is NULL or an empty vector, it won't
+# return logical(0). If a AND b are NULL/length-0, this will return TRUE; if
+# just one of them is NULL/length-0, this will FALSE. This is for use in
+# conditionals where `if(logical(0))` would cause an error. Similar to using
+# identical(a,b), but less stringent about types: `equals(1, 1L)` is TRUE, but
+# `identical(1, 1L)` is FALSE.
+equals <- function(a, b) {
+  alen <- length(a)
+  blen <- length(b)
+  if (alen==0 && blen==0) {
+    return(TRUE)
+  }
+  if (alen > 1 || blen > 1) {
+    stop("Can only compare objects of length 0 or 1")
+  }
+  if (alen==0 || blen==0) {
+    return(FALSE)
+  }
+
+  a == b
+}


### PR DESCRIPTION
This closes #152.

It adds the ability to restore selected `menuItem`s and `menuSubItem`s in the sidebar if they have a corresponding `tabItem`. However, `menuSubItem`s still don't have the ability to start expanded at this time, so although the tab content will be visible, the `menuSubItem` itself will not be.

Simple test app:

```R
library(shiny)

ui <- function(request) {
  sidebar <- dashboardSidebar(
    sidebarMenu(id = "sidebarmenu",
      menuItem("Dashboard", tabName = "dashboard", icon = icon("dashboard")),
      menuItem("Subitems",
        menuSubItem("Subitem 1", "subitem1"),
        menuSubItem("Subitem 2", "subitem2")
      ),
      menuItem("Widgets", icon = icon("th"), tabName = "widgets",
               badgeLabel = "new", badgeColor = "green"),
      bookmarkButton()
    )
  )
  
  body <- dashboardBody(
    tabItems(
      tabItem(tabName = "dashboard",
        h2("Dashboard tab content")
      ),
      tabItem(tabName = "subitem1",
        h2("Subitem 1 tab content")
      ),
      tabItem(tabName = "subitem2",
        h2("Subitem 2 tab content")
      ),
  
      tabItem(tabName = "widgets",
        h2("Widgets tab content")
      )
    )
  )
  
  dashboardPage(
    dashboardHeader(title = "Simple tabs"),
    sidebar,
    body
  )
}
server <- function(input, output) { }

shinyApp(ui, server, enableBookmarking = "url")
```