### PR TITLE
Fixes #176.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#176](https://github.com/rstudio/shinydashboard/issues/176) (making buttons look good on the sidebar) by giving buttons and anchor tags some margin space.
+
 * Updated to AdminLTE 2.3.11. ([#181](https://github.com/rstudio/shinydashboard/pull/181))
 
 shinydashboard 0.5.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 shinydashboard 0.5.3.9000
 =========================
 
-* Fixed [#176](https://github.com/rstudio/shinydashboard/issues/176) (making buttons look good on the sidebar) by giving buttons and anchor tags some margin space.
+* Fixed [#176](https://github.com/rstudio/shinydashboard/issues/176) (making buttons look good on the sidebar) by giving Shiny action buttons and links some margin space. ([#182](https://github.com/rstudio/shinydashboard/pull/182))
 
 * Updated to AdminLTE 2.3.11. ([#181](https://github.com/rstudio/shinydashboard/pull/181))
 

--- a/inst/shinydashboard.css
+++ b/inst/shinydashboard.css
@@ -33,9 +33,15 @@ section.sidebar .user-panel {
 /* Inputs in the sidebar */
 section.sidebar .shiny-input-container {
   /* Proper spacing around inputs. */
-  padding: 12px 15px 0px 12px;
+  padding: 12px 15px 0px 15px;
   /* Wrap content (important for inline inputs). */
   white-space: normal;
+}
+
+/* Make action buttons/links look good on the sidebar panel */
+section.sidebar button, section.sidebar a {
+  margin: 6px 5px 6px 15px;
+  display: block;
 }
 
 /* Shiny inputs in boxes should span full width. */
@@ -51,7 +57,6 @@ div.box-body .shiny-input-container {
 .sidebar .irs-min, .sidebar .irs-max {
   color: #aaa;
 }
-
 
 /* Don't highlight text when info box is in <a> tag */
 a > .info-box {

--- a/inst/shinydashboard.css
+++ b/inst/shinydashboard.css
@@ -39,7 +39,8 @@ section.sidebar .shiny-input-container {
 }
 
 /* Make action buttons/links look good on the sidebar panel */
-section.sidebar button, section.sidebar a {
+section.sidebar .shiny-bound-input.action-button,
+section.sidebar .shiny-bound-input.action-link {
   margin: 6px 5px 6px 15px;
   display: block;
 }


### PR DESCRIPTION
Made buttons look good on the sidebar by giving buttons and anchor tags some margin space.

I didn't make this specific to Shiny action buttons and action links. Rather, all button and anchor tags inside the sidebar will have this rule applied to them. I think this is what we want, right?