### PR TITLE
Fix #62: make images resize when the sidebar collapses/expands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#62](https://github.com/rstudio/shinydashboard/issues/62): make images resize when the sidebar collapses/expands. [#185](https://github.com/rstudio/shinydashboard/pull/185)
+
 * Addressed [#178](https://github.com/rstudio/shinydashboard/issues/178): switch from `npm` to `yarn`. Also upgraded all yarn packages to the `latest` tag (all major changes). [#184](https://github.com/rstudio/shinydashboard/pull/184)
 
 * Fixed [#176](https://github.com/rstudio/shinydashboard/issues/176) (making buttons look good on the sidebar) by giving Shiny action buttons and links some margin space. ([#182](https://github.com/rstudio/shinydashboard/pull/182))

--- a/inst/shinydashboard.js
+++ b/inst/shinydashboard.js
@@ -57,7 +57,7 @@ $(function() {
 
   // Trigger the resize event when the sidebar is collapsed/expanded
   // (this allows images to be responsive and resize themselves)
-  $(".sidebar-toggle").on( "click", function() {
+ $(document).on("click", ".sidebar-toggle", function() {
     $(window).trigger("resize");
   });
 

--- a/inst/shinydashboard.js
+++ b/inst/shinydashboard.js
@@ -55,6 +55,11 @@ $(function() {
     $(".navbar > .sidebar-toggle").hide();
   }
 
+  // Trigger the resize event when the sidebar is collapsed/expanded
+  // (this allows images to be responsive and resize themselves)
+  $(".sidebar-toggle").on( "click", function() {
+    $(window).trigger("resize");
+  });
 
   // menuOutputBinding
   // ------------------------------------------------------------------


### PR DESCRIPTION
Test app:

```r
library(shinydashboard)
library(shiny)

shinyApp(
  ui = dashboardPage(
    dashboardHeader(),
    dashboardSidebar(),
    dashboardBody(plotOutput("plot1"))
  ),
  server = function(input, output, session) {
    output$plot1 <- renderPlot({ plot(cars) })
  }
)
```