### PR TITLE
Add `collapsed` argument to dashboardSidebar()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#73](https://github.com/rstudio/shinydashboard/issues/73): add `collapsed` argument to `dashboardSidebar()`, which allows it to start off collapsed. ([#186](https://github.com/rstudio/shinydashboard/pull/186))
+
 * Fixed [#62](https://github.com/rstudio/shinydashboard/issues/62): make images resize when the sidebar collapses/expands. [#185](https://github.com/rstudio/shinydashboard/pull/185)
 
 * Addressed [#178](https://github.com/rstudio/shinydashboard/issues/178): switch from `npm` to `yarn`. Also upgraded all yarn packages to the `latest` tag (all major changes). [#184](https://github.com/rstudio/shinydashboard/pull/184)

--- a/R/dashboardPage.R
+++ b/R/dashboardPage.R
@@ -57,8 +57,16 @@ dashboardPage <- function(header, sidebar, body, title = NULL,
     body
   )
 
+  # if the sidebar has the class "start-collapsed", it means that the user set
+  # the `collapsed` argument of `dashboardSidebar` to TRUE
+  collapsed <- "start-collapsed" %in% strsplit(sidebar$attribs$class, " ")[[1]]
+
   addDeps(
-    tags$body(class = paste0("skin-", skin), style = "min-height: 611px;",
+    tags$body(
+      # the "sidebar-collapse" class on the body means that the sidebar should
+      # the collapsed (AdminLTE code)
+      class = paste0("skin-", skin, if (collapsed) " sidebar-collapse"),
+      style = "min-height: 611px;",
       shiny::bootstrapPage(content, title = title)
     )
   )

--- a/R/dashboardSidebar.R
+++ b/R/dashboardSidebar.R
@@ -8,6 +8,7 @@
 #' @param width The width of the sidebar. This must either be a number which
 #'   specifies the width in pixels, or a string that specifies the width in CSS
 #'   units.
+#' @param collapsed If \code{TRUE}, the sidebar will be collapsed on app startup.
 #'
 #' @seealso \code{\link{sidebarMenu}}
 #'
@@ -59,7 +60,7 @@
 #' )
 #' }
 #' @export
-dashboardSidebar <- function(..., disable = FALSE, width = NULL) {
+dashboardSidebar <- function(..., disable = FALSE, width = NULL, collapsed = FALSE) {
   width <- validateCssUnit(width)
 
   # Set up custom CSS for custom width
@@ -113,11 +114,15 @@ dashboardSidebar <- function(..., disable = FALSE, width = NULL) {
     '))))
   }
 
-  tags$aside(class = "main-sidebar",
+  # The expanded/collapsed state of the sidebar is actually set by adding a
+  # class to the body (not to the sidebar). However, it makes sense for the
+  # `collapsed` argument to belong in this function. So this information is
+  # just passed through (also as a class) to the `dashboardPage()` function
+  tags$aside(class = paste("main-sidebar", if (collapsed) "start-collapsed"),
     custom_css,
     tags$section(
       class = "sidebar",
-      `data-disable` = if(disable) 1 else NULL,
+      `data-disable` = if (disable) 1 else NULL,
       list(...)
     )
   )

--- a/man/dashboardSidebar.Rd
+++ b/man/dashboardSidebar.Rd
@@ -4,7 +4,7 @@
 \alias{dashboardSidebar}
 \title{Create a dashboard sidebar.}
 \usage{
-dashboardSidebar(..., disable = FALSE, width = NULL)
+dashboardSidebar(..., disable = FALSE, width = NULL, collapsed = FALSE)
 }
 \arguments{
 \item{...}{Items to put in the sidebar.}
@@ -14,6 +14,8 @@ dashboardSidebar(..., disable = FALSE, width = NULL)
 \item{width}{The width of the sidebar. This must either be a number which
 specifies the width in pixels, or a string that specifies the width in CSS
 units.}
+
+\item{collapsed}{If \code{TRUE}, the sidebar will be collapsed on app startup.}
 }
 \description{
 A dashboard sidebar typically contains a \code{\link{sidebarMenu}}, although


### PR DESCRIPTION
This allows the sidebar to start off collapsed (fixes #73).

Should the argument name be "collapsed" or "startCollapsed" (or something else)?

Example app:

```r
library(shinydashboard)
library(shiny)

shinyApp(
  ui = dashboardPage(
    dashboardHeader(),
    dashboardSidebar(collapsed = TRUE),
    dashboardBody()
  ),
  server = function(input, output, session) {}
)
```