### PR TITLE
detect and enforce selected tab for dynamic sidebars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#71](https://github.com/rstudio/shinydashboard/issues/71) and [#87](https://github.com/rstudio/shinydashboard/issues/87): detect and enforce selected tab for dynamic sidebars. ([#189](https://github.com/rstudio/shinydashboard/pull/189))
+
 * Fixed [#73](https://github.com/rstudio/shinydashboard/issues/73): add `collapsed` argument to `dashboardSidebar()`, which allows it to start off collapsed. ([#186](https://github.com/rstudio/shinydashboard/pull/186))
 
 * Fixed [#62](https://github.com/rstudio/shinydashboard/issues/62): make images resize when the sidebar collapses/expands. [#185](https://github.com/rstudio/shinydashboard/pull/185)

--- a/inst/shinydashboard.js
+++ b/inst/shinydashboard.js
@@ -100,6 +100,7 @@ $(function() {
 
       Shiny.initializeInputs(el);
       Shiny.bindAll(el);
+      ensureActivatedTab();
     }
   });
   Shiny.outputBindings.register(menuOutputBinding,


### PR DESCRIPTION
This is very simple fix, just running `ensureActivatedTab()` after `renderMenu` (renderValue method) is called. This allows for the correct tab to be selected for dynamic sidebars (closes #87, closes #71)

Here's an example app, from #71:

```r
library(shiny)
library(shinydashboard)

ui <- dashboardPage(
  dashboardHeader(title = "Dynamic sidebar"),
  dashboardSidebar(
    sidebarMenuOutput("menu")
  ),
  dashboardBody(tabItems(
    tabItem(tabName = "dashboard", h2("Dashboard tab content"))
  ))
)

server <- function(input, output) {
  output$menu <- renderMenu({
    sidebarMenu(id="mytabs",
      menuItem("Menu item", tabName="dashboard", icon = icon("calendar"))
    )
  })
}

shinyApp(ui, server)
```