### PR TITLE
Closes #129: Trigger shown/hidden event for Shiny outputs in the sidebar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#129](https://github.com/rstudio/shinydashboard/issues/129): Trigger shown/hidden event for Shiny outputs in the sidebar. ([#194](https://github.com/rstudio/shinydashboard/pull/194))
+	
 * Fixed [#73](https://github.com/rstudio/shinydashboard/issues/73): add `collapsed` argument to `dashboardSidebar()`, which allows it to start off collapsed. ([#186](https://github.com/rstudio/shinydashboard/pull/186))
 
 * Fixed [#62](https://github.com/rstudio/shinydashboard/issues/62): make images resize when the sidebar collapses/expands. [#185](https://github.com/rstudio/shinydashboard/pull/185)

--- a/inst/shinydashboard.js
+++ b/inst/shinydashboard.js
@@ -61,6 +61,10 @@ $(function() {
     $(window).trigger("resize");
   });
 
+ $(document).on("click", "a[href^='#shiny-tab']", function() {
+    $(this).next().trigger("shown");
+  });
+
   // menuOutputBinding
   // ------------------------------------------------------------------
   // Based on Shiny.htmlOutputBinding, but instead of putting the result in a

--- a/inst/shinydashboard.js
+++ b/inst/shinydashboard.js
@@ -62,7 +62,7 @@ $(function() {
   });
 
  $(document).on("click", ".treeview > a", function() {
-    $(this).next().trigger("shown");
+    $(this).next(".treeview-menu").trigger("shown");
   });
 
   // menuOutputBinding

--- a/inst/shinydashboard.js
+++ b/inst/shinydashboard.js
@@ -61,7 +61,7 @@ $(function() {
     $(window).trigger("resize");
   });
 
- $(document).on("click", "a[href^='#shiny-tab']", function() {
+ $(document).on("click", ".treeview > a", function() {
     $(this).next().trigger("shown");
   });
 


### PR DESCRIPTION
One thing I'm unhappy about is the jagged look of the expanded menu item when we first click it (so smooth transition, since the element actually has to be created)...

Example:

```r
library(shiny)
library(shinydashboard)

ui <- dashboardPage(
  dashboardHeader(),
  dashboardSidebar(
    sidebarMenu(
      menuItem("Menu Item", tabName = "tab1", textOutput("text1")),
      menuItem("Menu Item", tabName = "tab2", textOutput("text2"))
    )
  ),
  dashboardBody()
)

server <- function(input, output) {
  output$text1 <- renderText("text1")
  output$text2 <- renderText("text2")
}

shinyApp(ui = ui, server = server)
```