### PR TITLE
Inside a call to dashboardPage(), correctly extract title from dashboardHeader()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 shinydashboard 0.5.3.9000
 =========================
 
-* Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object ([#202](https://github.com/rstudio/shinydashboard/pull/202))
+* Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object ([#203](https://github.com/rstudio/shinydashboard/pull/203))
 	
 * Fixed [#129](https://github.com/rstudio/shinydashboard/issues/129): Trigger shown/hidden event for Shiny outputs in the sidebar. ([#194](https://github.com/rstudio/shinydashboard/pull/194))
 	

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object ([#202](https://github.com/rstudio/shinydashboard/pull/202))
+	
 * Fixed [#129](https://github.com/rstudio/shinydashboard/issues/129): Trigger shown/hidden event for Shiny outputs in the sidebar. ([#194](https://github.com/rstudio/shinydashboard/pull/194))
 	
 * Fixed [#73](https://github.com/rstudio/shinydashboard/issues/73): add `collapsed` argument to `dashboardSidebar()`, which allows it to start off collapsed. ([#186](https://github.com/rstudio/shinydashboard/pull/186))

--- a/R/dashboardPage.R
+++ b/R/dashboardPage.R
@@ -37,7 +37,7 @@ dashboardPage <- function(header, sidebar, body, title = NULL,
   skin <- match.arg(skin)
 
   extractTitle <- function(header) {
-    x <- header$children[[1]]
+    x <- header$children[[2]]
     if (x$name == "span" &&
         !is.null(x$attribs$class) &&
         x$attribs$class == "logo" &&


### PR DESCRIPTION
This closes #89. We claimed that `dashboardPage()` would try to extract the app's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object.

This must have worked at some point and then some change to the structure of the header object broke it.