### PR TITLE
Fix sidebar complete showing/hiding on mobile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 shinydashboard 0.5.3.9000
 =========================
 
-* Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object ([#203](https://github.com/rstudio/shinydashboard/pull/203))
+* Fixed [#127](https://github.com/rstudio/shinydashboard/issues/127) and [#177](https://github.com/rstudio/shinydashboard/issues/177): previously, if `dashboardSidebar()` was called with an explicit `width` parameter, mobile rendering would look weird (the sidebar wouldn't completely disappear when it was collapsed, and content in the dashboard body would be hidden under the still-visible sidebar). ([#204](https://github.com/rstudio/shinydashboard/pull/204))
+
+* Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object. ([#203](https://github.com/rstudio/shinydashboard/pull/203))
 	
 * Fixed [#129](https://github.com/rstudio/shinydashboard/issues/129): Trigger shown/hidden event for Shiny outputs in the sidebar. ([#194](https://github.com/rstudio/shinydashboard/pull/194))
 	

--- a/R/dashboardSidebar.R
+++ b/R/dashboardSidebar.R
@@ -72,6 +72,9 @@ dashboardSidebar <- function(..., disable = FALSE, width = NULL, collapsed = FAL
     # media query (min-width: 768px), so that it won't override other media
     # queries (like max-width: 767px) that work for narrower screens.
     custom_css <- tags$head(tags$style(HTML(gsub("_WIDTH_", width, fixed = TRUE, '
+      .main-sidebar, .left-side {
+        width: _WIDTH_;
+      }
       @media (min-width: 768px) {
         .content-wrapper,
         .right-side,


### PR DESCRIPTION
Fixes #127 and fixes #177: previously, if `dashboardSidebar()` was called with an explicit `width` parameter, mobile rendering would look weird (the sidebar wouldn't completely disappear when it was collapsed, and content in the dashboard body would be hidden under the still-visible sidebar).

Small example:
```r
library(shiny)
library(shinydashboard)
shinyApp(
    ui = dashboardPage(
        dashboardHeader(),
        dashboardSidebar(width = "150px"),
        dashboardBody("Hello world"),
        title = "Dashboard example"
    ),
    server = function(input, output) { }
)
```