### PR TITLE
Re-enable slight css transition when toggling sidebar visibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Fixed [#79](https://github.com/rstudio/shinydashboard/issues/79): Re-enable slight css transition when the sidebar is expanded/collapsed. ([#204](https://github.com/rstudio/shinydashboard/pull/204)).
+
 * Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object ([#203](https://github.com/rstudio/shinydashboard/pull/203))
 	
 * Fixed [#129](https://github.com/rstudio/shinydashboard/issues/129): Trigger shown/hidden event for Shiny outputs in the sidebar. ([#194](https://github.com/rstudio/shinydashboard/pull/194))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 shinydashboard 0.5.3.9000
 =========================
 
-* Fixed [#79](https://github.com/rstudio/shinydashboard/issues/79): Re-enable slight css transition when the sidebar is expanded/collapsed. ([#204](https://github.com/rstudio/shinydashboard/pull/204)).
+* Fixed [#79](https://github.com/rstudio/shinydashboard/issues/79): Re-enable slight css transition when the sidebar is expanded/collapsed. ([#205](https://github.com/rstudio/shinydashboard/pull/205)).
 
 * Fixed [#89](https://github.com/rstudio/shinydashboard/issues/89): We claimed that `dashboardPage()` would try to extract the page's title from `dashboardHeader()` (if the title is not provided directly to `dashboardPage()`); however, we were selecting the wrong child of the header tag object ([#203](https://github.com/rstudio/shinydashboard/pull/203))
 	

--- a/inst/shinydashboard.css
+++ b/inst/shinydashboard.css
@@ -64,24 +64,6 @@ a > .info-box {
   color: #333;
 }
 
-/* Disable bouncy transition for sidebar toggle. */
-.content-wrapper,
-.right-side,
-.main-footer {
-  -moz-transition: none;
-  -webkit-transition: none;
-  -o-transition: all 0 none;
-  transition: none;
-}
-.main-sidebar,
-.left-side {
-  -moz-transition: none;
-  -webkit-transition: none;
-  -o-transition: all 0 none;
-  transition: none;
-}
-
-
 /*  Shiny Server Pro logout panel needs to be raised above menu bar */
 .shiny-server-account {
   z-index: 2000;


### PR DESCRIPTION
Fixes #79.

For an example, any shinydashboard app with a sidebar will do:

```r
shinyApp(
    ui = dashboardPage(
        dashboardHeader(),
        dashboardSidebar(),
        dashboardBody()
    ),
    server = function(input, output) { }
)
```