### PR TITLE
Added a new optional argument, called `headerText` to the `dropdownMenu()` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 shinydashboard 0.5.3.9000
 =========================
 
+* Addressed [#165](https://github.com/rstudio/shinydashboard/issues/165): added a new optional argument, called `headerText` to the `dropdownMenu()` function. If provided by the user, this text (instead of the default) will be shown on the header of the menu (only visible when the menu is expanded). See `?dropdownMenu` for more details. [#207](https://github.com/rstudio/shinydashboard/pull/207)
+
 * Fixed [#127](https://github.com/rstudio/shinydashboard/issues/127) and [#177](https://github.com/rstudio/shinydashboard/issues/177): previously, if `dashboardSidebar()` was called with an explicit `width` parameter, mobile rendering would look weird (the sidebar wouldn't completely disappear when it was collapsed, and content in the dashboard body would be hidden under the still-visible sidebar). ([#204](https://github.com/rstudio/shinydashboard/pull/204))
 
 * Fixed [#79](https://github.com/rstudio/shinydashboard/issues/79): Re-enable slight css transition when the sidebar is expanded/collapsed. ([#205](https://github.com/rstudio/shinydashboard/pull/205)).

--- a/R/dashboardHeader.R
+++ b/R/dashboardHeader.R
@@ -149,6 +149,12 @@ dashboardHeader <- function(..., title = NULL, titleWidth = NULL, disable = FALS
 #' @param icon An icon to display in the header. By default, the icon is
 #'   automatically selected depending on \code{type}, but it can be overriden
 #'   with this argument.
+#' @param headerText An optional text argument used for the header of the
+#'   dropdown menu (this is only visible when the menu is expanded). If none is
+#'   provided by the user, the default is "You have \code{x} messages," where
+#'   \code{x} is the number of items in the menu (if the \code{type} is
+#'   specified to be "notifications" or "tasks," the default text shows "You
+#'   have \code{x} notifications" or  "You have \code{x} tasks," respectively).
 #' @param .list An optional list containing items to put in the menu Same as the
 #'   \code{...} arguments, but in list format. This can be useful when working
 #'   with programmatically generated items.
@@ -158,7 +164,8 @@ dashboardHeader <- function(..., title = NULL, titleWidth = NULL, disable = FALS
 #' @export
 dropdownMenu <- function(...,
   type = c("messages", "notifications", "tasks"),
-  badgeStatus = "primary", icon = NULL, .list = NULL)
+  badgeStatus = "primary", icon = NULL, headerText = NULL,
+  .list = NULL)
 {
   type <- match.arg(type)
   if (!is.null(badgeStatus)) validateStatus(badgeStatus)
@@ -184,13 +191,17 @@ dropdownMenu <- function(...,
     badge <- span(class = paste0("label label-", badgeStatus), numItems)
   }
 
+  if (is.null(headerText)) {
+    headerText <- paste("You have", numItems, type)
+  }
+
   tags$li(class = dropdownClass,
     a(href = "#", class = "dropdown-toggle", `data-toggle` = "dropdown",
       icon,
       badge
     ),
     tags$ul(class = "dropdown-menu",
-      tags$li(class = "header", paste("You have", numItems, type)),
+      tags$li(class = "header", headerText),
       tags$li(
         tags$ul(class = "menu",
           items

--- a/man/dropdownMenu.Rd
+++ b/man/dropdownMenu.Rd
@@ -5,7 +5,7 @@
 \title{Create a dropdown menu to place in a dashboard header}
 \usage{
 dropdownMenu(..., type = c("messages", "notifications", "tasks"),
-  badgeStatus = "primary", icon = NULL, .list = NULL)
+  badgeStatus = "primary", icon = NULL, headerText = NULL, .list = NULL)
 }
 \arguments{
 \item{...}{Items to put in the menu. Typically, message menus should contain
@@ -24,6 +24,13 @@ badge.}
 \item{icon}{An icon to display in the header. By default, the icon is
 automatically selected depending on \code{type}, but it can be overriden
 with this argument.}
+
+\item{headerText}{An optional text argument used for the header of the
+dropdown menu (this is only visible when the menu is expanded). If none is
+provided by the user, the default is "You have \code{x} messages," where
+\code{x} is the number of items in the menu (if the \code{type} is
+specified to be "notifications" or "tasks," the default text shows "You
+have \code{x} notifications" or  "You have \code{x} tasks," respectively).}
 
 \item{.list}{An optional list containing items to put in the menu Same as the
 \code{...} arguments, but in list format. This can be useful when working


### PR DESCRIPTION
If provided by the user, this text (instead of the default) will be shown on the header of the menu (only visible when the menu is expanded).

Closes #165.

Example app (covers 3 scenarios):

```r
library(shiny)
library(shinydashboard)

messages <- list(
  messageItem("Support", "This is the content of a message.", time = "5 mins"),
  messageItem("Support", "This is the content of another message.", time = "2 hours"),
  messageItem("New User", "Can I get some help?", time = "Today" )
)

notifications <- list(
  notificationItem(icon = icon("users"), status = "info", "5 new members joined today"),
  notificationItem(icon = icon("warning"), status = "danger", "Resource usage near limit."),
  notificationItem(icon = icon("shopping-cart", lib = "glyphicon"),  status = "success", "25 sales made"),
  notificationItem(icon = icon("user", lib = "glyphicon"), status = "danger", "You changed your username")
)

tasks <- list(
  taskItem(value = 20, color = "aqua", "Refactor code"),
  taskItem(value = 40, color = "green", "Design new layout"),
  taskItem(value = 60, color = "yellow", "Another task"),
  taskItem(value = 80, color = "red", "Write documentation")
)

ui <- dashboardPage(
  dashboardHeader(
    title = "Dashboard Demo",
    
    # Keeps default text
    dropdownMenu(type = "messages", badgeStatus = "success", .list = messages),
    
    # Overrides default text
    dropdownMenu(type = "notifications", badgeStatus = "warning",
      headerText = "These are important notifications!",
      .list = notifications
    ),
    
    # Overrides default text in a more complicated way
    dropdownMenu(type = "tasks", badgeStatus = "danger",
      .list = tasks, headerText = paste("Tens", length(tasks), "tarefas.")
    )
  ),
  dashboardSidebar(),
  dashboardBody()
)

server <- function(input, output, session) {}
shinyApp(ui, server)
```