### PR TITLE
Add necessary CSS selectors for new FontAwesome

### DIFF
--- a/inst/shinydashboard.css
+++ b/inst/shinydashboard.css
@@ -16,6 +16,10 @@
 
 .navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .glyphicon,
 .navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .fa,
+.navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .fab,
+.navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .fas,
+.navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .far,
+.navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .fal,
 .navbar-nav > .messages-menu > .dropdown-menu > li .menu > li > a > .ion {
   float: left;
   font-size: 30px;


### PR DESCRIPTION
New FontAwesome icons aren't guaranteed to have class `fa` anymore. Brands have `fab`, solid (normal) icons can have `fas`, regular icons (some are free, most are FontAwesome Pro only) have class `far` and light icons (FontAwesome Pro only) have `fal` as "primary" class.

See https://github.com/rstudio/shiny/issues/2260