### PR TITLE
add "hidden-xs" class to logo  …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,4 +20,4 @@ Imports:
     htmltools (>= 0.2.6),
     promises
 BugReports: https://github.com/rstudio/shinydashboard
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1

--- a/R/dashboardHeader.R
+++ b/R/dashboardHeader.R
@@ -115,7 +115,8 @@ dashboardHeader <- function(..., title = NULL, titleWidth = NULL, disable = FALS
   tags$header(class = "main-header",
     custom_css,
     style = if (disable) "display: none;",
-    span(class = "logo", title),
+    # hide logo on small screen devices only if title is NULL
+    span(class = if (is.null(title)) "logo hidden-xs" else "logo", title),
     tags$nav(class = "navbar navbar-static-top", role = "navigation",
       # Embed hidden icon so that we get the font-awesome dependency
       span(shiny::icon("bars"), style = "display:none;"),

--- a/man/dashboardHeader.Rd
+++ b/man/dashboardHeader.Rd
@@ -4,8 +4,8 @@
 \alias{dashboardHeader}
 \title{Create a header for a dashboard page}
 \usage{
-dashboardHeader(..., title = NULL, titleWidth = NULL, disable = FALSE,
-  .list = NULL)
+dashboardHeader(..., title = NULL, titleWidth = NULL,
+  disable = FALSE, .list = NULL)
 }
 \arguments{
 \item{...}{Items to put in the header. Should be \code{\link{dropdownMenu}}s.}

--- a/man/dashboardPage.Rd
+++ b/man/dashboardPage.Rd
@@ -4,8 +4,8 @@
 \alias{dashboardPage}
 \title{Dashboard page}
 \usage{
-dashboardPage(header, sidebar, body, title = NULL, skin = c("blue", "black",
-  "purple", "green", "red", "yellow"))
+dashboardPage(header, sidebar, body, title = NULL, skin = c("blue",
+  "black", "purple", "green", "red", "yellow"))
 }
 \arguments{
 \item{header}{A header created by \code{dashboardHeader}.}

--- a/man/dashboardSidebar.Rd
+++ b/man/dashboardSidebar.Rd
@@ -4,7 +4,8 @@
 \alias{dashboardSidebar}
 \title{Create a dashboard sidebar.}
 \usage{
-dashboardSidebar(..., disable = FALSE, width = NULL, collapsed = FALSE)
+dashboardSidebar(..., disable = FALSE, width = NULL,
+  collapsed = FALSE)
 }
 \arguments{
 \item{...}{Items to put in the sidebar.}

--- a/man/dropdownMenu.Rd
+++ b/man/dropdownMenu.Rd
@@ -5,7 +5,8 @@
 \title{Create a dropdown menu to place in a dashboard header}
 \usage{
 dropdownMenu(..., type = c("messages", "notifications", "tasks"),
-  badgeStatus = "primary", icon = NULL, headerText = NULL, .list = NULL)
+  badgeStatus = "primary", icon = NULL, headerText = NULL,
+  .list = NULL)
 }
 \arguments{
 \item{...}{Items to put in the menu. Typically, message menus should contain

--- a/man/notificationItem.Rd
+++ b/man/notificationItem.Rd
@@ -4,8 +4,8 @@
 \alias{notificationItem}
 \title{Create a notification item to place in a dropdown notification menu}
 \usage{
-notificationItem(text, icon = shiny::icon("warning"), status = "success",
-  href = NULL)
+notificationItem(text, icon = shiny::icon("warning"),
+  status = "success", href = NULL)
 }
 \arguments{
 \item{text}{The notification text.}

--- a/man/sidebarMenu.Rd
+++ b/man/sidebarMenu.Rd
@@ -8,10 +8,10 @@
 \usage{
 sidebarMenu(..., id = NULL, .list = NULL)
 
-menuItem(text, ..., icon = NULL, badgeLabel = NULL, badgeColor = "green",
-  tabName = NULL, href = NULL, newtab = TRUE, selected = NULL,
-  expandedName = as.character(gsub("[[:space:]]", "", text)),
-  startExpanded = FALSE)
+menuItem(text, ..., icon = NULL, badgeLabel = NULL,
+  badgeColor = "green", tabName = NULL, href = NULL, newtab = TRUE,
+  selected = NULL, expandedName = as.character(gsub("[[:space:]]", "",
+  text)), startExpanded = FALSE)
 
 menuSubItem(text, tabName = NULL, href = NULL, newtab = TRUE,
   icon = shiny::icon("angle-double-right"), selected = NULL)


### PR DESCRIPTION
Consider the following example with the current version of shinydashboard, on a cellphone for instance:

```r
library(shiny)
library(shinydashboard)
shinyApp(
  ui = dashboardPage(
    dashboardHeader(),
    dashboardSidebar(),
    dashboardBody(),
    title = "Dashboard example"
  ),
  server = function(input, output) { }
)
```

![capture d ecran 2019-02-12 a 08 56 05](https://user-images.githubusercontent.com/18291543/52621679-3def7f00-2ea8-11e9-8638-230fef2c19d5.png)

We have a blue bar above the sidebar trigger taking unnecessary vertical space.

This simple PR aims at adding the extra class "hidden-xs" to "logo", so that it is not displayed on small screen devices when the title is NULL in dashboardheader (even though it is better to give a title):

```r
span(class = if (is.null(title)) "logo hidden-xs" else "logo", title)
```