### PR TITLE
add scroll option to box

### DIFF
--- a/R/boxes.R
+++ b/R/boxes.R
@@ -119,6 +119,8 @@ infoBox <- function(title, value = NULL, subtitle = NULL,
 #'   the user to collapse the box.
 #' @param collapsed If TRUE, start collapsed. This must be used with
 #'   \code{collapsible=TRUE}.
+#' @param scroll If TRUE and height is specified the box includes a scroll bar and
+#' will allow vertical scroll if contents exceeds height of box
 #' @param ... Contents of the box.
 #'
 #' @family boxes
@@ -250,7 +252,8 @@ infoBox <- function(title, value = NULL, subtitle = NULL,
 #' @export
 box <- function(..., title = NULL, footer = NULL, status = NULL,
                 solidHeader = FALSE, background = NULL, width = 6,
-                height = NULL, collapsible = FALSE, collapsed = FALSE) {
+                height = NULL, collapsible = FALSE, collapsed = FALSE,
+                scroll = FALSE) {
 
   boxClass <- "box"
   if (solidHeader || !is.null(background)) {
@@ -267,10 +270,17 @@ box <- function(..., title = NULL, footer = NULL, status = NULL,
     validateColor(background)
     boxClass <- paste0(boxClass, " bg-", background)
   }
+  if (scroll & !is.null(height)){
+    boxClass <- paste(boxClass, "scroll-box")
+  }
 
   style <- NULL
   if (!is.null(height)) {
-    style <- paste0("height: ", validateCssUnit(height))
+    style <- paste0("height: ", validateCssUnit(height), ";")
+
+    if (scroll){
+      style <- paste0(style, "overflow-y: scroll;")
+    }
   }
 
   titleTag <- NULL


### PR DESCRIPTION
This PR allows for users to create a scroll-able box if they specify the height. The scroll bar is created if height is defined and scroll = TRUE and scrolling is enabled if the height of the content exceeds the height of the box. 

While the scroll bar can be added manually to the `box` class in a css file, it can only be added to all boxes as a result. Users are unable to change or add to the class of the top `div` in the `box` output. Specifying the class argument in the `box` function appends to the class of the inner `div` which does not look as good for the scroll bar. This function will add the style and the class to the top `div` if the height is specified also. 

I looked at adding it to `tabBox` for consistency but it seems more practical to allow to the user to just define the class and/or style to `tabPanel` as setting class or style in that function access the top div of the tab. 

If there is anything else I should do to help get this merged, please let me know!

Thanks!