### PR TITLE
align shinydashboard tab data-value with shiny tabs

### DIFF
--- a/R/tabs.R
+++ b/R/tabs.R
@@ -31,6 +31,7 @@ tabItem <- function(tabName = NULL, ...) {
     role = "tabpanel",
     class = "tab-pane",
     id = paste0("shiny-tab-", tabName),
+    `data-value` = tabName,
     ...
   )
 }


### PR DESCRIPTION
I guess you'd probably want to update the codebase to use `bslib`, but since that is a lot of work updating shiny dashboard tabs to include a `data-value` will allow other shiny related packages (like [mine](https://github.com/carlganz/rintrojs/issues/56)) to work with tabs across shiny and shiny dashboard in a generic way (see https://github.com/carlganz/rintrojs/blob/master/inst/javascript/rintro.js#L48)