### PR TITLE
fix: Properly alias `shiny::updateTabsetPanel()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,5 @@ Imports:
     htmltools (>= 0.2.6),
     promises
 BugReports: https://github.com/rstudio/shinydashboard
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,5 @@ Imports:
     htmltools (>= 0.2.6),
     promises
 BugReports: https://github.com/rstudio/shinydashboard
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinydashboard
 Title: Create Dashboards with 'Shiny'
-Version: 0.7.2
+Version: 0.7.2.9000
 Authors@R: c(
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),
     person("Barbara", "Borges Ribeiro", role = "aut", email = "barbara@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # shinydashboard (development version)
 
+### Bug fixes
+
+* Fixed [#397](https://github.com/rstudio/shinydashboard/issues/397): `updateTabItems()` is now a run-time alias of `shiny::updateTabsetPanel()`. ([#398](https://github.com/rstudio/shinydashboard/pull/398))
+
 shinydashboard 0.7.2
 ====================
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# shinydashboard (development version)
+
 shinydashboard 0.7.2
 ====================
 

--- a/R/tabs.R
+++ b/R/tabs.R
@@ -40,7 +40,7 @@ tabItem <- function(tabName = NULL, ...) {
 #' This function controls the active tab of \code{\link{tabItems}} from the
 #' server. It behaves just like \code{\link[shiny]{updateTabsetPanel}}.
 #'
-#' @inheritParams shiny::updateTabsetPanel
+#' @inheritDotParams shiny::updateTabsetPanel
 #' @examples
 #' ## Only run this example in interactive R sessions
 #' if (interactive()) {
@@ -80,4 +80,6 @@ tabItem <- function(tabName = NULL, ...) {
 #' shinyApp(ui, server)
 #' }
 #' @export
-updateTabItems <- shiny::updateTabsetPanel
+updateTabItems <- function(...) {
+  shiny::updateTabsetPanel(...)
+}

--- a/man/renderDropdownMenu.Rd
+++ b/man/renderDropdownMenu.Rd
@@ -7,7 +7,7 @@
 renderDropdownMenu(expr, env = parent.frame(), quoted = FALSE)
 }
 \arguments{
-\item{expr}{An expression that returns a Shiny tag object, \code{\link[shiny:reexports]{HTML()}},
+\item{expr}{An expression that returns a Shiny tag object, \code{\link[shiny:HTML]{HTML()}},
 or a list of such objects.}
 
 \item{env}{The parent environment for the reactive expression. By default,

--- a/man/renderMenu.Rd
+++ b/man/renderMenu.Rd
@@ -7,7 +7,7 @@
 renderMenu(expr, env = parent.frame(), quoted = FALSE, outputArgs = list())
 }
 \arguments{
-\item{expr}{An expression that returns a Shiny tag object, \code{\link[shiny:reexports]{HTML()}},
+\item{expr}{An expression that returns a Shiny tag object, \code{\link[shiny:HTML]{HTML()}},
 or a list of such objects.}
 
 \item{env}{The parent environment for the reactive expression. By default,
@@ -21,7 +21,7 @@ would like to use its expression as a value for \code{expr}, then you must set
 \code{quoted} to \code{TRUE}.}
 
 \item{outputArgs}{A list of arguments to be passed through to the implicit
-call to \code{\link[shiny:htmlOutput]{uiOutput()}} when \code{renderUI} is used in an
+call to \code{\link[shiny:uiOutput]{uiOutput()}} when \code{renderUI} is used in an
 interactive R Markdown document.}
 }
 \description{

--- a/man/renderValueBox.Rd
+++ b/man/renderValueBox.Rd
@@ -10,7 +10,7 @@ renderValueBox(expr, env = parent.frame(), quoted = FALSE)
 renderInfoBox(expr, env = parent.frame(), quoted = FALSE)
 }
 \arguments{
-\item{expr}{An expression that returns a Shiny tag object, \code{\link[shiny:reexports]{HTML()}},
+\item{expr}{An expression that returns a Shiny tag object, \code{\link[shiny:HTML]{HTML()}},
 or a list of such objects.}
 
 \item{env}{The parent environment for the reactive expression. By default,

--- a/man/updateTabItems.Rd
+++ b/man/updateTabItems.Rd
@@ -4,18 +4,20 @@
 \alias{updateTabItems}
 \title{Change the selected tab on the client}
 \usage{
-updateTabItems(session = getDefaultReactiveDomain(), inputId, selected = NULL)
+updateTabItems(...)
 }
 \arguments{
-\item{session}{The \code{session} object passed to function given to
+\item{...}{
+  Arguments passed on to \code{\link[shiny:updateTabsetPanel]{shiny::updateTabsetPanel}}
+  \describe{
+    \item{\code{session}}{The \code{session} object passed to function given to
 \code{shinyServer}. Default is \code{getDefaultReactiveDomain()}.}
-
-\item{inputId}{The id of the \code{tabsetPanel}, \code{navlistPanel},
+    \item{\code{inputId}}{The id of the \code{tabsetPanel}, \code{navlistPanel},
 or \code{navbarPage} object.}
-
-\item{selected}{The \code{value} (or, if none was supplied, the \code{title})
+    \item{\code{selected}}{The \code{value} (or, if none was supplied, the \code{title})
 of the tab that should be selected by default. If \code{NULL}, the first
 tab will be selected.}
+  }}
 }
 \description{
 This function controls the active tab of \code{\link{tabItems}} from the


### PR DESCRIPTION
Fixes #397 by using a function wrapper `updateTabPanel()` that passes `...` down to `shiny::updateTabsetPanel()`